### PR TITLE
Added test_suite_type to group test cases.

### DIFF
--- a/src/test_case_mod.F90
+++ b/src/test_case_mod.F90
@@ -31,65 +31,93 @@ module test_case_mod
     type(assert_result_type), pointer :: assert_result_tail => null()
   end type test_case_type
 
-  integer num_test_case
-  type(test_case_type), pointer :: test_case_head => null()
-  type(test_case_type), pointer :: test_case_tail => null()
-  type(test_case_type), pointer :: curr_test_case => null()
+  type test_suite_type
+      character(256) :: name = "A test suite"
+      integer :: num_test_case = 0
+      type(test_case_type), pointer :: test_case_head => null()
+      type(test_case_type), pointer :: test_case_tail => null()
+      type(test_case_type), pointer :: curr_test_case => null()
+  end type test_suite_type
+
+  type(test_suite_type), target, private :: default_test_suite
 
 contains
 
   subroutine test_case_init()
 
-    num_test_case = 0
+    default_test_suite%name = "Default test suite"
 
   end subroutine test_case_init
 
-  subroutine test_case_final()
+  subroutine test_case_final(suite)
+      type(test_suite_type), optional, target :: suite
+      type(test_suite_type), pointer :: dummy_suite
+      type(test_case_type), pointer :: test_case1, test_case2
+      type(assert_result_type), pointer :: assert_result1, assert_result2
 
-    type(test_case_type), pointer :: test_case1, test_case2
-    type(assert_result_type), pointer :: assert_result1, assert_result2
+      ! if no suite parameter was passed, use default test suite
+      if( present(suite) ) then
+          dummy_suite => suite
+      else
+          dummy_suite => default_test_suite
+      end if
 
-    test_case1 => test_case_head
-    do while (associated(test_case1))
-      test_case2 => test_case1%next
-      assert_result1 => test_case1%assert_result_head
-      do while (associated(assert_result1))
-        assert_result2 => assert_result1%next
-        deallocate(assert_result1)
-        assert_result1 => assert_result2
+      test_case1 => dummy_suite%test_case_head
+      do while (associated(test_case1))
+          test_case2 => test_case1%next
+          assert_result1 => test_case1%assert_result_head
+          do while (associated(assert_result1))
+              assert_result2 => assert_result1%next
+              deallocate(assert_result1)
+              assert_result1 => assert_result2
+          end do
+          deallocate(test_case1)
+          test_case1 => test_case2
       end do
-      deallocate(test_case1)
-      test_case1 => test_case2
-    end do
 
   end subroutine test_case_final
 
-  subroutine test_case_create(name)
-
+  subroutine test_case_create(name, suite)
     character(*), intent(in) :: name
+    type(test_suite_type), target, optional :: suite
+    type(test_suite_type), pointer :: dummy_suite
 
-    if (.not. associated(test_case_head)) then
-      allocate(test_case_head)
-      test_case_tail => test_case_head
+    ! if no suite parameter was passed, use default test suite
+    if( present(suite) ) then
+        dummy_suite => suite
     else
-      allocate(test_case_tail%next)
-      test_case_tail => test_case_tail%next
+        dummy_suite => default_test_suite
     end if
-    test_case_tail%name = name
-    curr_test_case => test_case_tail
 
-    num_test_case = num_test_case + 1
+    if (.not. associated(dummy_suite%test_case_head)) then
+      allocate(dummy_suite%test_case_head)
+      dummy_suite%test_case_tail => dummy_suite%test_case_head
+    else
+      allocate(dummy_suite%test_case_tail%next)
+      dummy_suite%test_case_tail => dummy_suite%test_case_tail%next
+    end if
+    dummy_suite%test_case_tail%name = name
+    dummy_suite%curr_test_case => dummy_suite%test_case_tail
+
+    dummy_suite%num_test_case = dummy_suite%num_test_case + 1
 
   end subroutine test_case_create
 
-  subroutine test_case_report(name)
-
+  subroutine test_case_report(name, suite)
     character(*), intent(in) :: name
-
+    type(test_suite_type), optional, target :: suite
+    type(test_suite_type), pointer :: dummy_suite
     type(test_case_type), pointer :: test_case
     type(assert_result_type), pointer :: assert_result
 
-    test_case => get_test_case(name)
+    ! if no suite parameter was passed, use default test suite
+    if( present(suite) ) then
+        dummy_suite => suite
+    else
+        dummy_suite => default_test_suite
+    end if
+
+    test_case => get_test_case(name, suite)
 
     call log_header(log_out_unit, 'Test case report')
     write(log_out_unit, *) trim(test_case%name) // ': ', trim(to_string(test_case%num_succeed_assert)), ' of ' // &
@@ -114,39 +142,55 @@ contains
 
   end subroutine test_case_report
 
-  subroutine test_case_append_assert(assert_operator, passed, left_operand, right_operand)
+  subroutine test_case_append_assert(assert_operator, passed, left_operand, right_operand, suite)
 
     character(*), intent(in) :: assert_operator
     logical, intent(in) :: passed
     character(*), intent(in) :: left_operand
     character(*), intent(in), optional :: right_operand
+    type(test_suite_type), target, optional :: suite
+    type(test_suite_type), pointer :: dummy_suite
 
-    if (.not. associated(curr_test_case%assert_result_head)) then
-      allocate(curr_test_case%assert_result_head)
-      curr_test_case%assert_result_tail => curr_test_case%assert_result_head
+    ! if no suite parameter was passed, use default test suite
+    if( present(suite) ) then
+        dummy_suite => suite
     else
-      allocate(curr_test_case%assert_result_tail%next)
-      curr_test_case%assert_result_tail => curr_test_case%assert_result_tail%next
+        dummy_suite => default_test_suite
     end if
-    curr_test_case%assert_result_tail%assert_operator = assert_operator
-    curr_test_case%assert_result_tail%passed = passed
-    curr_test_case%assert_result_tail%left_operand = left_operand
-    if (present(right_operand)) curr_test_case%assert_result_tail%right_operand = right_operand
-    curr_test_case%num_assert = curr_test_case%num_assert + 1
-    if (passed) curr_test_case%num_succeed_assert = curr_test_case%num_succeed_assert + 1
-    curr_test_case%assert_result_tail%id = curr_test_case%num_assert
+
+    if (.not. associated(dummy_suite%curr_test_case%assert_result_head)) then
+      allocate(dummy_suite%curr_test_case%assert_result_head)
+      dummy_suite%curr_test_case%assert_result_tail => dummy_suite%curr_test_case%assert_result_head
+    else
+      allocate(dummy_suite%curr_test_case%assert_result_tail%next)
+      dummy_suite%curr_test_case%assert_result_tail => dummy_suite%curr_test_case%assert_result_tail%next
+    end if
+    dummy_suite%curr_test_case%assert_result_tail%assert_operator = assert_operator
+    dummy_suite%curr_test_case%assert_result_tail%passed = passed
+    dummy_suite%curr_test_case%assert_result_tail%left_operand = left_operand
+    if (present(right_operand)) dummy_suite%curr_test_case%assert_result_tail%right_operand = right_operand
+    dummy_suite%curr_test_case%num_assert = dummy_suite%curr_test_case%num_assert + 1
+    if (passed) dummy_suite%curr_test_case%num_succeed_assert = dummy_suite%curr_test_case%num_succeed_assert + 1
+    dummy_suite%curr_test_case%assert_result_tail%id = dummy_suite%curr_test_case%num_assert
 
   end subroutine test_case_append_assert
 
-  function get_test_case(name) result(res)
-
+  function get_test_case(name, suite) result(res)
+    integer i
     character(*), intent(in) :: name
     type(test_case_type), pointer :: res
+    type(test_suite_type), target, optional :: suite
+    type(test_suite_type), pointer :: dummy_suite
 
-    integer i
+    ! if no suite parameter was passed, use default test suite
+    if( present(suite) ) then
+        dummy_suite => suite
+    else
+        dummy_suite => default_test_suite
+    end if
 
-    res => test_case_head
-    do i = 1, num_test_case
+    res => dummy_suite%test_case_head
+    do i = 1, dummy_suite%num_test_case
       if (res%name == name) then
         exit
       end if

--- a/src/test_case_mod.F90
+++ b/src/test_case_mod.F90
@@ -32,11 +32,11 @@ module test_case_mod
   end type test_case_type
 
   type test_suite_type
-      character(256) :: name = "A test suite"
-      integer :: num_test_case = 0
-      type(test_case_type), pointer :: test_case_head => null()
-      type(test_case_type), pointer :: test_case_tail => null()
-      type(test_case_type), pointer :: curr_test_case => null()
+    character(256) :: name = "A test suite"
+    integer :: num_test_case = 0
+    type(test_case_type), pointer :: test_case_head => null()
+    type(test_case_type), pointer :: test_case_tail => null()
+    type(test_case_type), pointer :: curr_test_case => null()
   end type test_suite_type
 
   type(test_suite_type), target, private :: default_test_suite
@@ -50,43 +50,45 @@ contains
   end subroutine test_case_init
 
   subroutine test_case_final(suite)
-      type(test_suite_type), optional, target :: suite
-      type(test_suite_type), pointer :: dummy_suite
-      type(test_case_type), pointer :: test_case1, test_case2
-      type(assert_result_type), pointer :: assert_result1, assert_result2
 
-      ! if no suite parameter was passed, use default test suite
-      if( present(suite) ) then
-          dummy_suite => suite
-      else
-          dummy_suite => default_test_suite
-      end if
+    type(test_suite_type), optional, target :: suite
+    type(test_suite_type), pointer :: dummy_suite
+    type(test_case_type), pointer :: test_case1, test_case2
+    type(assert_result_type), pointer :: assert_result1, assert_result2
 
-      test_case1 => dummy_suite%test_case_head
-      do while (associated(test_case1))
-          test_case2 => test_case1%next
-          assert_result1 => test_case1%assert_result_head
-          do while (associated(assert_result1))
-              assert_result2 => assert_result1%next
-              deallocate(assert_result1)
-              assert_result1 => assert_result2
-          end do
-          deallocate(test_case1)
-          test_case1 => test_case2
+    ! if no suite parameter was passed, use default test suite
+    if( present(suite) ) then
+      dummy_suite => suite
+    else
+      dummy_suite => default_test_suite
+    end if
+
+    test_case1 => dummy_suite%test_case_head
+    do while (associated(test_case1))
+      test_case2 => test_case1%next
+      assert_result1 => test_case1%assert_result_head
+      do while (associated(assert_result1))
+        assert_result2 => assert_result1%next
+        deallocate(assert_result1)
+        assert_result1 => assert_result2
       end do
+      deallocate(test_case1)
+      test_case1 => test_case2
+    end do
 
   end subroutine test_case_final
 
   subroutine test_case_create(name, suite)
+
     character(*), intent(in) :: name
     type(test_suite_type), target, optional :: suite
     type(test_suite_type), pointer :: dummy_suite
 
     ! if no suite parameter was passed, use default test suite
     if( present(suite) ) then
-        dummy_suite => suite
+      dummy_suite => suite
     else
-        dummy_suite => default_test_suite
+      dummy_suite => default_test_suite
     end if
 
     if (.not. associated(dummy_suite%test_case_head)) then
@@ -104,6 +106,7 @@ contains
   end subroutine test_case_create
 
   subroutine test_case_report(name, suite)
+
     character(*), intent(in) :: name
     type(test_suite_type), optional, target :: suite
     type(test_suite_type), pointer :: dummy_suite
@@ -112,9 +115,9 @@ contains
 
     ! if no suite parameter was passed, use default test suite
     if( present(suite) ) then
-        dummy_suite => suite
+      dummy_suite => suite
     else
-        dummy_suite => default_test_suite
+      dummy_suite => default_test_suite
     end if
 
     test_case => get_test_case(name, suite)
@@ -153,9 +156,9 @@ contains
 
     ! if no suite parameter was passed, use default test suite
     if( present(suite) ) then
-        dummy_suite => suite
+      dummy_suite => suite
     else
-        dummy_suite => default_test_suite
+      dummy_suite => default_test_suite
     end if
 
     if (.not. associated(dummy_suite%curr_test_case%assert_result_head)) then
@@ -176,6 +179,7 @@ contains
   end subroutine test_case_append_assert
 
   function get_test_case(name, suite) result(res)
+
     integer i
     character(*), intent(in) :: name
     type(test_case_type), pointer :: res
@@ -184,9 +188,9 @@ contains
 
     ! if no suite parameter was passed, use default test suite
     if( present(suite) ) then
-        dummy_suite => suite
+      dummy_suite => suite
     else
-        dummy_suite => default_test_suite
+      dummy_suite => default_test_suite
     end if
 
     res => dummy_suite%test_case_head


### PR DESCRIPTION
Hi,

I've been looking for a unit test framework in Fortran and found your repository. I like that it is in pure Fortran and would like to use it in my projects.

I thought that for larger projects, it might be useful to group test cases into test suites, so I added a type for that. Currently, the change is minimal (it does not actually add much functionality). I tried to set up the infrastructure for test suites without changing the current user interface.