### PR TITLE
Changed mod name to ensure compatibility with repository fortran-string.

### DIFF
--- a/src/assert_mod.F90
+++ b/src/assert_mod.F90
@@ -1,7 +1,7 @@
 module assert_mod
 
   use log_mod
-  use string_mod
+  use simple_string_mod
   use test_case_mod
 
   implicit none

--- a/src/log_mod.F90
+++ b/src/log_mod.F90
@@ -1,6 +1,6 @@
 module log_mod
 
-  use string_mod
+  use simple_string_mod
 
   implicit none
 

--- a/src/string_mod.F90
+++ b/src/string_mod.F90
@@ -1,4 +1,4 @@
-module string_mod
+module simple_string_mod
 
   implicit none
 
@@ -119,4 +119,4 @@ contains
 
   end function logical_to_string
 
-end module string_mod
+end module simple_string_mod

--- a/src/test_case_mod.F90
+++ b/src/test_case_mod.F90
@@ -1,7 +1,7 @@
 module test_case_mod
 
   use log_mod
-  use string_mod
+  use simple_string_mod
 
   implicit none
 


### PR DESCRIPTION
The string_mod is not compatabile with the new repository fortran_string. Deleting the file will cause a circular dependency. Maybe you have an better idea then my attempt?