### PR TITLE
Add fpm support https://fpm.fortran-lang.org/

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,10 @@
+name = "fortran-unit-test"
+version = "0.0.1"
+license = "MIT"
+author = "Li Dong"
+maintainer = "https://github.com/dongli"
+copyright = "Copyright (c) 2017 Li Dong"
+
+
+[library]
+source-dir="src"


### PR DESCRIPTION
Add support for the fpm Fortran Package Manager build system:

https://fpm.fortran-lang.org/

Added the git tag 0.0.1 as fpm wants the fortran-unit-test to have a git tag.